### PR TITLE
Add login page and environment-based auth

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Optional
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
@@ -9,7 +10,7 @@ from passlib.context import CryptContext
 from . import schemas
 from .supabase_db import db
 
-SECRET_KEY = "CHANGE_ME"  # in production use environment variable
+SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/app/supabase_db.py
+++ b/app/supabase_db.py
@@ -5,10 +5,12 @@ from urllib import request, parse, error
 
 class SupabaseDB:
     def __init__(self):
-        self.url = "https://bvobkbervdxeflwittlp.supabase.co"
-        self.key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ2b2JrYmVydmR4ZWZsd2l0dGxwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI4MjU0NjEsImV4cCI6MjA2ODQwMTQ2MX0.y6j4Utub7QoJnLl4QbDMFzz2mFpfP7Bjw1uqp-ZaRzk"
+        self.url = os.getenv("SUPABASE_URL")
+        self.key = os.getenv("SUPABASE_KEY")
         if not self.url or not self.key:
-            raise RuntimeError("SUPABASE_URL and SUPABASE_KEY environment variables must be set")
+            raise RuntimeError(
+                "SUPABASE_URL and SUPABASE_KEY environment variables must be set"
+            )
         # Ensure base URL ends without trailing slash
         self.rest_url = self.url.rstrip("/") + "/rest/v1"
         self.headers = {

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,6 +1,6 @@
-import { Bell, Settings, User, ChevronDown, Sun, Moon } from 'lucide-react';
+import { Bell, Settings, User, ChevronDown, Sun, Moon, LogOut } from 'lucide-react';
 
-export default function Header({ theme, toggleTheme, setPage, page }) {
+export default function Header({ theme, toggleTheme, setPage, page, onLogout, user }) {
   return (
     <header className="flex justify-between items-center p-4 text-gray-800 dark:text-white">
       <div className="text-2xl font-bold tracking-wider">
@@ -54,8 +54,10 @@ export default function Header({ theme, toggleTheme, setPage, page }) {
           </button>
           <div className="flex items-center space-x-2">
             <User size={24} className="p-1 bg-cyan-500 rounded-full text-white" />
-            <span className="hidden sm:inline">Alex Doe</span>
-            <ChevronDown size={16} />
+            <span className="hidden sm:inline">{user?.username || 'User'}</span>
+            <button onClick={onLogout} className="p-1" title="Logout">
+              <LogOut size={16} />
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+export default function LoginPage({ onLogin, theme }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const body = new URLSearchParams();
+      body.append('username', username);
+      body.append('password', password);
+      const res = await fetch('http://localhost:8000/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+      if (!res.ok) {
+        throw new Error('Invalid credentials');
+      }
+      const data = await res.json();
+      onLogin(data.access_token);
+    } catch (err) {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
+      <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-8 rounded shadow-md w-80">
+        <h2 className="text-2xl mb-4 text-center text-gray-800 dark:text-gray-100">Login</h2>
+        {error && <p className="text-red-500 mb-2">{error}</p>}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Username</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 text-gray-800 dark:text-white focus:outline-none"
+          />
+        </div>
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-3 py-2 border rounded-md bg-gray-50 dark:bg-gray-700 text-gray-800 dark:text-white focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full py-2 px-4 bg-cyan-600 hover:bg-cyan-700 text-white rounded-md"
+        >
+          Sign In
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- read secret and Supabase credentials from env vars
- add frontend login page and authentication state
- integrate logout functionality

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a0d427fb08330b62b30eb01074400