### PR TITLE
Add user registration UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,10 +5,12 @@ import DashboardPage from './pages/DashboardPage';
 import UserManagementPage from './pages/UserManagementPage';
 import StrategiesPage from './pages/StrategiesPage';
 import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
 
 export default function App() {
   const [theme, setTheme] = useState('dark');
   const [page, setPage] = useState('dashboard');
+  const [authPage, setAuthPage] = useState('login');
   const [token, setToken] = useState(localStorage.getItem('token'));
   const [user, setUser] = useState(null);
 
@@ -64,7 +66,21 @@ export default function App() {
   };
 
   if (!token) {
-    return <LoginPage onLogin={handleLogin} theme={theme} />;
+    if (authPage === 'register') {
+      return (
+        <RegisterPage
+          onRegistered={() => setAuthPage('login')}
+          goToLogin={() => setAuthPage('login')}
+        />
+      );
+    }
+    return (
+      <LoginPage
+        onLogin={handleLogin}
+        theme={theme}
+        goToRegister={() => setAuthPage('register')}
+      />
+    );
   }
 
   return (

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,37 +1,39 @@
 import { useState } from 'react';
 
-export default function LoginPage({ onLogin, theme, goToRegister }) {
+export default function RegisterPage({ onRegistered, goToLogin }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
     try {
-      const body = new URLSearchParams();
-      body.append('username', username);
-      body.append('password', password);
-      const res = await fetch('http://localhost:8000/token', {
+      const res = await fetch('http://localhost:8000/register', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
       });
       if (!res.ok) {
-        throw new Error('Invalid credentials');
+        const data = await res.json();
+        throw new Error(data.detail || 'Registration failed');
       }
-      const data = await res.json();
-      onLogin(data.access_token);
+      setSuccess(true);
+      setUsername('');
+      setPassword('');
+      if (onRegistered) onRegistered();
     } catch (err) {
-      setError('Login failed');
+      setError(err.message);
     }
   };
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
       <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-8 rounded shadow-md w-80">
-        <h2 className="text-2xl mb-4 text-center text-gray-800 dark:text-gray-100">Login</h2>
+        <h2 className="text-2xl mb-4 text-center text-gray-800 dark:text-gray-100">Register</h2>
         {error && <p className="text-red-500 mb-2">{error}</p>}
+        {success && <p className="text-green-500 mb-2">Registration successful!</p>}
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Username</label>
           <input
@@ -54,14 +56,14 @@ export default function LoginPage({ onLogin, theme, goToRegister }) {
           type="submit"
           className="w-full py-2 px-4 bg-cyan-600 hover:bg-cyan-700 text-white rounded-md mb-2"
         >
-          Sign In
+          Register
         </button>
         <button
           type="button"
-          onClick={goToRegister}
+          onClick={goToLogin}
           className="w-full py-2 px-4 bg-black/10 dark:bg-white/10 text-gray-800 dark:text-gray-200 rounded-md"
         >
-          Register
+          Back to Login
         </button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add front-end page to register a new user
- navigate between login and registration pages

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687a15165a108330bb62b946dc7071d3