### PR TITLE
Fix bcrypt compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 fastapi
 uvicorn
 python-jose
-passlib[bcrypt]
+# Pin passlib and bcrypt versions to avoid incompatibility between
+# passlib's bcrypt backend and newer versions of the bcrypt package
+passlib[bcrypt]==1.7.4
+bcrypt==3.2.0
 redis


### PR DESCRIPTION
## Summary
- pin `passlib` and `bcrypt` versions to avoid incompatibility where `bcrypt` no longer exposes `__about__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a192cfce083308e8a02393ffd0d03