### PR TITLE
Implement real user management and approval

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -25,6 +25,7 @@ class UserCreate(UserBase):
 
 class User(UserBase):
     id: int
+    status: str
     trades: List[Trade] = []
 
     class Config:

--- a/app/supabase_db.py
+++ b/app/supabase_db.py
@@ -39,8 +39,8 @@ class SupabaseDB:
             raise RuntimeError(f"Supabase request failed: {exc.code} {msg}") from None
 
     # User operations
-    def create_user(self, username: str, hashed_password: str):
-        data = {"username": username, "hashed_password": hashed_password}
+    def create_user(self, username: str, hashed_password: str, status: str = "Pending"):
+        data = {"username": username, "hashed_password": hashed_password, "status": status}
         res = self._request("POST", "/users", data=data)
         return res[0] if res else None
 
@@ -52,6 +52,15 @@ class SupabaseDB:
     def get_user(self, user_id: int):
         params = {"id": f"eq.{user_id}"}
         res = self._request("GET", "/users", params=params)
+        return res[0] if res else None
+
+    def get_users(self):
+        return self._request("GET", "/users", params={})
+
+    def update_user_status(self, user_id: int, status: str):
+        params = {"id": f"eq.{user_id}"}
+        data = {"status": status}
+        res = self._request("PATCH", "/users", params=params, data=data)
         return res[0] if res else None
 
     # Trade operations

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -18,12 +18,13 @@ export default function LoginPage({ onLogin, theme, goToRegister }) {
         body,
       });
       if (!res.ok) {
-        throw new Error('Invalid credentials');
+        const data = await res.json();
+        throw new Error(data.detail || 'Invalid credentials');
       }
       const data = await res.json();
       onLogin(data.access_token);
     } catch (err) {
-      setError('Login failed');
+      setError(err.message || 'Login failed');
     }
   };
 


### PR DESCRIPTION
## Summary
- expand user schema with `status`
- store new users as `Pending` and block login unless `Active`
- expose endpoints to list users and update status
- extend Supabase helper with user listing and status update
- improve login error handling
- wire frontend user management page to real API data and status updates

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687a1bc4fbc083309e209044d37c4ed3