### PR TITLE
Fix Supabase POST requests returning empty body

### DIFF
--- a/app/supabase_db.py
+++ b/app/supabase_db.py
@@ -24,10 +24,18 @@ class SupabaseDB:
         if params:
             query = parse.urlencode(params)
             url += f"?{query}"
+
+        headers = self.headers.copy()
+        if method in {"POST", "PATCH", "PUT", "DELETE"}:
+            # Return the affected row(s) so the calling code receives the full
+            # representation rather than an empty body
+            headers["Prefer"] = "return=representation"
+
         data_bytes = None
         if data is not None:
             data_bytes = json.dumps(data).encode()
-        req = request.Request(url, method=method, headers=self.headers, data=data_bytes)
+
+        req = request.Request(url, method=method, headers=headers, data=data_bytes)
         try:
             with request.urlopen(req) as resp:
                 resp_data = resp.read().decode()


### PR DESCRIPTION
## Summary
- ensure Supabase REST requests include `Prefer: return=representation`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687a1ff3721083309a3f4f636bb0a38f