### PR TITLE
Add toast for user approval

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "lucide-react": "^0.378.0",
-    "recharts": "^2.8.0"
+    "recharts": "^2.8.0",
+    "react-hot-toast": "^2.4.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import UserManagementPage from './pages/UserManagementPage';
 import StrategiesPage from './pages/StrategiesPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import { Toaster } from 'react-hot-toast';
 
 export default function App() {
   const [theme, setTheme] = useState('dark');
@@ -86,6 +87,7 @@ export default function App() {
   return (
     <div className="relative min-h-screen font-sans transition-colors duration-500 bg-gray-100 dark:bg-gray-900">
       <ParticleBackground theme={theme} />
+      <Toaster position="top-right" />
       <div className="relative z-10 min-h-screen w-full h-full">
         <Header
           theme={theme}

--- a/frontend/src/pages/UserManagementPage.jsx
+++ b/frontend/src/pages/UserManagementPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Search, CheckCircle, XCircle, UserX } from 'lucide-react';
 import GlassCard from '../components/GlassCard';
 import StatusBadge from '../components/StatusBadge';
+import { toast } from 'react-hot-toast';
 
 export default function UserManagementPage() {
   const [users, setUsers] = useState([]);
@@ -25,6 +26,9 @@ export default function UserManagementPage() {
       .then((res) => res.json())
       .then((updated) => {
         setUsers(users.map((u) => (u.id === userId ? updated : u)));
+        if (newStatus === 'Active') {
+          toast.success('User approved successfully');
+        }
       })
       .catch(() => {});
   };


### PR DESCRIPTION
## Summary
- add `react-hot-toast` dependency
- display `<Toaster />` in the root App component
- show success toast when approving a user

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687a2285c3548330990b28be59fb0e44