### PR TITLE
Add Test strategy using Binance API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,10 @@
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, Body
 from fastapi.middleware.cors import CORSMiddleware
 import os
 
 from . import schemas, crud, auth, cache, settings
+from .supabase_db import db
+from binance.client import Client
 
 app = FastAPI(title="Tradex API")
 
@@ -20,6 +22,23 @@ app.add_middleware(
 
 app.include_router(auth.router)
 app.include_router(settings.router)
+
+
+@app.post("/strategy/test")
+def run_test_strategy(
+    symbol: str = Body(..., embed=True),
+    current_user: dict = Depends(auth.get_current_user),
+):
+    user_settings = db.get_user_settings(current_user["id"])
+    if not user_settings:
+        raise HTTPException(status_code=400, detail="Binance API keys not configured")
+    client = Client(user_settings["binance_api_key"], user_settings["binance_api_secret"])
+    try:
+        buy = client.create_order(symbol=symbol.upper(), side="BUY", type="MARKET", quantity=1)
+        sell = client.create_order(symbol=symbol.upper(), side="SELL", type="MARKET", quantity=1)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"buy": buy, "sell": sell}
 
 
 @app.post("/trades/", response_model=schemas.Trade)

--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -1,63 +1,53 @@
 import { useState } from 'react';
-import { TrendingUp, PlayCircle, StopCircle } from 'lucide-react';
+import { PlayCircle } from 'lucide-react';
 import GlassCard from '../components/GlassCard';
-import StatusBadge from '../components/StatusBadge';
-
-const initialStrategies = [
-  { id: 1, name: 'Momentum Scalper v2', description: 'A high-frequency strategy that capitalizes on small price movements in volatile markets.', successRate: 82.4, status: 'Active' },
-  { id: 2, name: 'Mean Reversion Pro', description: 'Identifies overextended price moves and trades on the expectation of a return to the mean.', successRate: 76.1, status: 'Inactive' },
-  { id: 3, name: 'Arbitrage Finder', description: 'Scans multiple exchanges to find and exploit price discrepancies for the same asset.', successRate: 98.2, status: 'Active' },
-  { id: 4, name: 'Trend Follower AI', description: 'Uses machine learning to identify and follow long-term market trends for sustained gains.', successRate: 68.9, status: 'Inactive' },
-];
-
-const StrategyCard = ({ strategy, onToggle }) => {
-  const isActive = strategy.status === 'Active';
-  const successRateColor = strategy.successRate > 80 ? 'text-green-400' : strategy.successRate > 70 ? 'text-yellow-400' : 'text-red-400';
-
-  return (
-    <GlassCard className="flex flex-col justify-between">
-      <div>
-        <div className="flex justify-between items-start mb-2">
-          <h3 className="text-xl font-semibold text-gray-800 dark:text-white">{strategy.name}</h3>
-          <StatusBadge status={strategy.status} />
-        </div>
-        <p className="text-gray-600 dark:text-gray-300 text-sm mb-4 h-16">{strategy.description}</p>
-      </div>
-      <div>
-        <div className="flex justify-between items-center mb-4">
-          <div className="flex items-center space-x-2 text-gray-700 dark:text-gray-200">
-            <TrendingUp size={20} />
-            <span>Last Week's Success</span>
-          </div>
-          <span className={`text-lg font-bold ${successRateColor}`}>{strategy.successRate}%</span>
-        </div>
-        <button onClick={() => onToggle(strategy.id)} className={`w-full py-3 rounded-lg text-white font-bold text-lg transition-all duration-300 flex items-center justify-center space-x-2 ${isActive ? 'bg-red-500 hover:bg-red-600 shadow-red-500/30' : 'bg-green-500 hover:bg-green-600 shadow-green-500/30'} shadow-lg`}>
-          {isActive ? <StopCircle size={20} /> : <PlayCircle size={20} />}
-          <span>{isActive ? 'STOP STRATEGY' : 'START STRATEGY'}</span>
-        </button>
-      </div>
-    </GlassCard>
-  );
-};
+import { toast } from 'react-hot-toast';
 
 export default function StrategiesPage() {
-  const [strategies, setStrategies] = useState(initialStrategies);
+  const [symbol, setSymbol] = useState('');
+  const token = localStorage.getItem('token');
 
-  const handleToggleStrategy = (strategyId) => {
-    setStrategies(strategies.map((s) => (s.id === strategyId ? { ...s, status: s.status === 'Active' ? 'Inactive' : 'Active' } : s)));
+  const runStrategy = () => {
+    if (!symbol) return;
+    fetch('http://localhost:8000/strategy/test', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ symbol }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error();
+        return res.json();
+      })
+      .then(() => toast.success('Strategy executed'))
+      .catch(() => toast.error('Error executing strategy'));
   };
 
   return (
     <main className="p-4 sm:p-6 lg:p-8">
       <div className="mb-6 px-2">
         <h2 className="text-2xl font-semibold text-gray-800 dark:text-white">Strategy Management</h2>
-        <p className="text-gray-600 dark:text-gray-400">Activate or deactivate trading strategies.</p>
+        <p className="text-gray-600 dark:text-gray-400">Execute available strategies.</p>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6">
-        {strategies.map((strategy) => (
-          <StrategyCard key={strategy.id} strategy={strategy} onToggle={handleToggleStrategy} />
-        ))}
-      </div>
+      <GlassCard className="max-w-md mx-auto space-y-4">
+        <h3 className="text-xl font-semibold text-gray-800 dark:text-white">Test Strategy</h3>
+        <input
+          type="text"
+          placeholder="Trading pair e.g. XRPUSDT"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value.toUpperCase())}
+          className="w-full px-3 py-2 border rounded bg-gray-50 dark:bg-gray-700 text-gray-800 dark:text-white"
+        />
+        <button
+          onClick={runStrategy}
+          className="w-full py-3 rounded-lg text-white font-bold text-lg bg-green-500 hover:bg-green-600 flex items-center justify-center space-x-2 shadow-lg"
+        >
+          <PlayCircle size={20} />
+          <span>RUN STRATEGY</span>
+        </button>
+      </GlassCard>
     </main>
   );
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ passlib[bcrypt]==1.7.4
 bcrypt==3.2.0
 redis
 cryptography
+python-binance


### PR DESCRIPTION
## Summary
- add `python-binance` dependency
- create backend endpoint `/strategy/test` to place a market buy then sell
- rebuild Strategies page to let user submit a trading pair and execute strategy

## Testing
- `pip install -r requirements.txt` *(fails: cannot connect to pypi)*

------
https://chatgpt.com/codex/tasks/task_b_687a2b4d2f4c8330a11ece5783570713