### PR TITLE
Add buy/sell flow for test strategy

### DIFF
--- a/app/strategies.py
+++ b/app/strategies.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends, HTTPException, Body
+from binance.client import Client
+
+from . import auth
+from .supabase_db import db
+
+router = APIRouter()
+
+
+def _get_client(user_id: int) -> Client:
+    settings = db.get_user_settings(user_id)
+    if not settings:
+        raise HTTPException(status_code=400, detail="Binance API keys not configured")
+    return Client(settings["binance_api_key"], settings["binance_api_secret"])
+
+
+@router.post("/strategy/test/buy")
+def test_buy(
+    symbol: str = Body(..., embed=True),
+    amount: float = Body(..., embed=True),
+    current_user: dict = Depends(auth.get_current_user),
+):
+    client = _get_client(current_user["id"])
+    try:
+        order = client.create_order(
+            symbol=symbol.upper(),
+            side="BUY",
+            type="MARKET",
+            quoteOrderQty=amount,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"buy": order}
+
+
+@router.post("/strategy/test/sell")
+def test_sell(
+    symbol: str = Body(..., embed=True),
+    quantity: float = Body(..., embed=True),
+    current_user: dict = Depends(auth.get_current_user),
+):
+    client = _get_client(current_user["id"])
+    try:
+        order = client.create_order(
+            symbol=symbol.upper(),
+            side="SELL",
+            type="MARKET",
+            quantity=quantity,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"sell": order}

--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -5,25 +5,49 @@ import { toast } from 'react-hot-toast';
 
 export default function StrategiesPage() {
   const [symbol, setSymbol] = useState('');
+  const [amount, setAmount] = useState('');
+  const [mode, setMode] = useState('buy');
   const token = localStorage.getItem('token');
 
-  const runStrategy = () => {
-    if (!symbol) return;
-    fetch('http://localhost:8000/strategy/test', {
+  const handleAction = () => {
+    if (!symbol || !amount) return;
+    const endpoint =
+      mode === 'buy' ? '/strategy/test/buy' : '/strategy/test/sell';
+    const payload =
+      mode === 'buy'
+        ? { symbol, amount: parseFloat(amount) }
+        : { symbol, quantity: parseFloat(amount) };
+
+    fetch(`http://localhost:8000${endpoint}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ symbol }),
+      body: JSON.stringify(payload),
     })
       .then((res) => {
         if (!res.ok) throw new Error();
         return res.json();
       })
-      .then(() => toast.success('Strategy executed'))
-      .catch(() => toast.error('Error executing strategy'));
+      .then((data) => {
+        if (mode === 'buy') {
+          toast.success('Bought successfully');
+          const qty = data.buy?.executedQty || amount;
+          setAmount(qty);
+          setMode('sell');
+        } else {
+          toast.success('Sold successfully');
+          setMode('buy');
+          setAmount('');
+        }
+      })
+      .catch(() => toast.error('Error executing order'));
   };
+
+  const base = symbol.endsWith('USDT') ? symbol.replace('USDT', '') : symbol;
+  const amountPlaceholder = mode === 'buy' ? 'Amount in USDT' : `Amount in ${base}`;
+  const buttonColor = mode === 'buy' ? 'bg-green-500 hover:bg-green-600' : 'bg-red-500 hover:bg-red-600';
 
   return (
     <main className="p-4 sm:p-6 lg:p-8">
@@ -40,12 +64,19 @@ export default function StrategiesPage() {
           onChange={(e) => setSymbol(e.target.value.toUpperCase())}
           className="w-full px-3 py-2 border rounded bg-gray-50 dark:bg-gray-700 text-gray-800 dark:text-white"
         />
+        <input
+          type="text"
+          placeholder={amountPlaceholder}
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-full px-3 py-2 border rounded bg-gray-50 dark:bg-gray-700 text-gray-800 dark:text-white"
+        />
         <button
-          onClick={runStrategy}
-          className="w-full py-3 rounded-lg text-white font-bold text-lg bg-green-500 hover:bg-green-600 flex items-center justify-center space-x-2 shadow-lg"
+          onClick={handleAction}
+          className={`w-full py-3 rounded-lg text-white font-bold text-lg flex items-center justify-center space-x-2 shadow-lg ${buttonColor}`}
         >
           <PlayCircle size={20} />
-          <span>RUN STRATEGY</span>
+          <span>{mode === 'buy' ? 'BUY' : 'SELL'}</span>
         </button>
       </GlassCard>
     </main>


### PR DESCRIPTION
## Summary
- move strategy logic into a new `strategies.py`
- expose `/strategy/test/buy` and `/strategy/test/sell` endpoints
- hook new router in `main.py`
- update frontend Strategy page with buy-then-sell workflow

## Testing
- `python -m py_compile app/main.py app/strategies.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a2ec805dc8330b93b92d48d19b276