### PR TITLE
Add Binance assets page

### DIFF
--- a/app/assets.py
+++ b/app/assets.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, HTTPException
+from binance.client import Client
+
+from . import auth
+from .supabase_db import db
+
+router = APIRouter()
+
+
+def _get_client(user_id: int) -> Client:
+    settings = db.get_user_settings(user_id)
+    if not settings:
+        raise HTTPException(status_code=400, detail="Binance API keys not configured")
+    return Client(settings["binance_api_key"], settings["binance_api_secret"])
+
+
+@router.get("/assets")
+def get_assets(current_user: dict = Depends(auth.get_current_user)):
+    client = _get_client(current_user["id"])
+    try:
+        account = client.get_account()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    balances = account.get("balances", [])
+    non_zero = [b for b in balances if float(b.get("free", 0)) > 0 or float(b.get("locked", 0)) > 0]
+    return {"balances": non_zero}

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import os
 
-from . import schemas, crud, auth, cache, settings, strategies
+from . import schemas, crud, auth, cache, settings, strategies, assets
 
 app = FastAPI(title="Tradex API")
 
@@ -21,6 +21,7 @@ app.add_middleware(
 app.include_router(auth.router)
 app.include_router(settings.router)
 app.include_router(strategies.router)
+app.include_router(assets.router)
 
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import DashboardPage from './pages/DashboardPage';
 import UserManagementPage from './pages/UserManagementPage';
 import StrategiesPage from './pages/StrategiesPage';
+import AssetsPage from './pages/AssetsPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import { Toaster } from 'react-hot-toast';
@@ -63,6 +64,8 @@ export default function App() {
         return <UserManagementPage />;
       case 'strategies':
         return <StrategiesPage />;
+      case 'assets':
+        return <AssetsPage />;
       default:
         return <DashboardPage theme={theme} />;
     }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -35,6 +35,15 @@ export default function Header({ theme, toggleTheme, setPage, page, onLogout, us
           >
             Strategies
           </a>
+          <a
+            href="#"
+            onClick={() => setPage('assets')}
+            className={`${
+              page === 'assets' ? 'text-cyan-600 dark:text-cyan-400' : ''
+            } hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors`}
+          >
+            Assets
+          </a>
           <a href="#" className="hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors">
             Analytics
           </a>

--- a/frontend/src/pages/AssetsPage.jsx
+++ b/frontend/src/pages/AssetsPage.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import GlassCard from '../components/GlassCard';
+
+export default function AssetsPage() {
+  const [assets, setAssets] = useState([]);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    fetch('http://localhost:8000/assets', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then((data) => setAssets(data.balances || []))
+      .catch(() => setAssets([]));
+  }, [token]);
+
+  const filtered = assets.filter(
+    (a) => parseFloat(a.free) > 0 || parseFloat(a.locked) > 0
+  );
+
+  return (
+    <main className="p-4 sm:p-6 lg:p-8">
+      <GlassCard>
+        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Binance Assets</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-gray-600 dark:text-gray-300">
+            <thead className="border-b border-gray-400/20 dark:border-white/20">
+              <tr>
+                <th className="p-4">Asset</th>
+                <th className="p-4 text-right">Free</th>
+                <th className="p-4 text-right">Locked</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((asset) => (
+                <tr
+                  key={asset.asset}
+                  className="border-b border-gray-400/10 dark:border-white/10 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                >
+                  <td className="p-4 font-semibold text-gray-800 dark:text-white">{asset.asset}</td>
+                  <td className="p-4 text-right">{parseFloat(asset.free).toFixed(8)}</td>
+                  <td className="p-4 text-right">{parseFloat(asset.locked).toFixed(8)}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan="3" className="p-4 text-center text-gray-500">
+                    No assets found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </GlassCard>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `assets.py` router to fetch Binance account balances
- expose new router in FastAPI app
- create frontend AssetsPage to display Binance assets
- add navigation link for Assets and handle routing

## Testing
- `python -m py_compile app/main.py app/assets.py`

------
https://chatgpt.com/codex/tasks/task_b_687a34efc21483309a859f228ec9d4b2