### PR TITLE
Fix dashboard token handling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,7 +59,7 @@ export default function App() {
   const renderPage = () => {
     switch (page) {
       case 'dashboard':
-        return <DashboardPage theme={theme} />;
+        return <DashboardPage theme={theme} token={token} />;
       case 'users':
         return <UserManagementPage />;
       case 'strategies':
@@ -67,7 +67,7 @@ export default function App() {
       case 'assets':
         return <AssetsPage />;
       default:
-        return <DashboardPage theme={theme} />;
+        return <DashboardPage theme={theme} token={token} />;
     }
   };
 

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -129,7 +129,7 @@ const TradeHistoryTable = ({ tradeHistory }) => (
   </GlassCard>
 );
 
-export default function DashboardPage({ theme }) {
+export default function DashboardPage({ theme, token }) {
   const [chartData, setChartData] = useState([]);
   const [tradeHistory, setTradeHistory] = useState([]);
   const [stats, setStats] = useState({
@@ -139,7 +139,6 @@ export default function DashboardPage({ theme }) {
     avg_trade_duration: 0,
   });
 
-  const token = localStorage.getItem('token');
 
   useEffect(() => {
     fetch('http://localhost:8000/dashboard', {


### PR DESCRIPTION
## Summary
- pass token prop from `App` down to `DashboardPage`
- use token prop directly in the dashboard when fetching data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687d24033454833085567fe13133c07c