### PR TITLE
Add bot config endpoints and UI

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from . import auth, schemas
+from .supabase_db import db
+
+router = APIRouter()
+
+
+@router.get("/bot", response_model=schemas.BotConfig)
+def get_bot_config(current_user: dict = Depends(auth.get_current_user)):
+    config = db.get_bot_config(current_user["id"])
+    if not config:
+        raise HTTPException(status_code=404, detail="Bot config not found")
+    return config
+
+
+@router.post("/bot", response_model=schemas.BotConfig)
+def update_bot_config(
+    config: schemas.BotConfigCreate,
+    current_user: dict = Depends(auth.get_current_user),
+):
+    updated = db.upsert_bot_config(
+        current_user["id"],
+        config.strategy,
+        config.risk_level,
+        config.market,
+        config.is_active,
+    )
+    return updated
+

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,17 @@ from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import os
 
-from . import schemas, crud, auth, cache, settings, strategies, assets, dashboard
+from . import (
+    schemas,
+    crud,
+    auth,
+    cache,
+    settings,
+    strategies,
+    assets,
+    dashboard,
+    bot,
+)
 
 app = FastAPI(title="Tradex API")
 
@@ -23,6 +33,7 @@ app.include_router(settings.router)
 app.include_router(strategies.router)
 app.include_router(assets.router)
 app.include_router(dashboard.router)
+app.include_router(bot.router)
 
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -47,3 +47,22 @@ class UserSettings(UserSettingsBase):
 
     class Config:
         orm_mode = True
+
+
+class BotConfigBase(BaseModel):
+    strategy: str
+    risk_level: str
+    market: str
+    is_active: bool
+
+
+class BotConfigCreate(BotConfigBase):
+    pass
+
+
+class BotConfig(BotConfigBase):
+    id: int
+    user_id: int
+
+    class Config:
+        orm_mode = True

--- a/app/supabase_db.py
+++ b/app/supabase_db.py
@@ -135,5 +135,34 @@ class SupabaseDB:
         res = self._request("POST", "/user_settings", data=data)
         return res[0] if res else None
 
+    # Bot config operations
+    def get_bot_config(self, user_id: int):
+        params = {"user_id": f"eq.{user_id}"}
+        res = self._request("GET", "/bot_configs", params=params)
+        return res[0] if res else None
+
+    def upsert_bot_config(
+        self,
+        user_id: int,
+        strategy: str,
+        risk_level: str,
+        market: str,
+        is_active: bool,
+    ):
+        data = {
+            "strategy": strategy,
+            "risk_level": risk_level,
+            "market": market,
+            "is_active": is_active,
+        }
+        existing = self.get_bot_config(user_id)
+        if existing:
+            params = {"user_id": f"eq.{user_id}"}
+            res = self._request("PATCH", "/bot_configs", params=params, data=data)
+            return res[0] if res else None
+        data["user_id"] = user_id
+        res = self._request("POST", "/bot_configs", data=data)
+        return res[0] if res else None
+
 
 db = SupabaseDB()


### PR DESCRIPTION
## Summary
- add `BotConfig` schema and Supabase helpers
- expose `/bot` API endpoints
- wire up router in `main.py`
- fetch bot configuration in dashboard and allow toggling

## Testing
- `python -m py_compile app/*.py`
- `npm -C frontend run build` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687d284c1fb483309d66cf23783fa929