### PR TITLE
Pin numpy/pandas-ta versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This project contains a simple FastAPI backend for a crypto and stock trading bo
    pip install -r requirements.txt
    ```
    Whenever `requirements.txt` is updated, re-run the command above to reinstall
-   the dependencies.
+   the dependencies. The file pins `numpy<2.0` and `pandas-ta>=0.3.14` for
+   compatibility.
 2. Create a project in [Supabase](https://supabase.com) and create the following tables:
    - `users` and `trades` matching the models in `app/schemas.py`.
    - `user_settings` using the SQL below.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ redis
 cryptography
 python-binance
 pandas
-pandas-ta
+numpy<2.0
+pandas-ta>=0.3.14
 setuptools


### PR DESCRIPTION
## Summary
- pin numpy<2.0 and pandas-ta>=0.3.14 in requirements
- mention pinned versions in setup instructions

## Testing
- `python -m pip check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e10e68a988330bb6c31633b5031fa