### PR TITLE
Remove pandas-ta dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+venv/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# pyenv-virtualenv
+
+# VS Code
+.vscode/
+
+# Data files
+*.log
+
+# Local virtualenv
+venv/
+

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This project contains a simple FastAPI backend for a crypto and stock trading bo
    pip install -r requirements.txt
    ```
    Whenever `requirements.txt` is updated, re-run the command above to reinstall
-   the dependencies. The file pins `numpy<2.0` and `pandas-ta>=0.3.14` for
-   compatibility.
+   the dependencies. The file pins `numpy<2.0` for compatibility and includes
+   basic indicator helpers so no external `pandas-ta` package is required.
 2. Create a project in [Supabase](https://supabase.com) and create the following tables:
    - `users` and `trades` matching the models in `app/schemas.py`.
    - `user_settings` using the SQL below.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ cryptography
 python-binance
 pandas
 numpy<2.0
-pandas-ta>=0.3.14
 setuptools


### PR DESCRIPTION
## Summary
- drop pandas-ta from requirements
- update README to mention built-in indicator helpers
- implement custom indicator helpers in `SqueezeBreakoutStrategy`
- add `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687e128e912c83308c06b6b52e997f20