### PR TITLE
Add strategy management UI

### DIFF
--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -1,13 +1,28 @@
-import { useState } from 'react';
-import { PlayCircle } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { PlayCircle, StopCircle } from 'lucide-react';
 import GlassCard from '../components/GlassCard';
 import { toast } from 'react-hot-toast';
+
+const AVAILABLE_STRATEGIES = [
+  { id: 'squeeze_breakout', name: 'Squeeze Breakout' },
+  { id: 'squeeze_breakout_doge_1h', name: 'DOGEUSDT 1H Squeeze Breakout' },
+];
 
 export default function StrategiesPage() {
   const [symbol, setSymbol] = useState('');
   const [amount, setAmount] = useState('');
   const [mode, setMode] = useState('buy');
+  const [botConfig, setBotConfig] = useState(null);
   const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    fetch('http://localhost:8000/bot', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then(setBotConfig)
+      .catch(() => setBotConfig(null));
+  }, [token]);
 
   const handleAction = () => {
     if (!symbol || !amount) return;
@@ -49,13 +64,36 @@ export default function StrategiesPage() {
   const amountPlaceholder = mode === 'buy' ? 'Amount in USDT' : `Amount in ${base}`;
   const buttonColor = mode === 'buy' ? 'bg-green-500 hover:bg-green-600' : 'bg-red-500 hover:bg-red-600';
 
+  const updateBot = (strategy, isActive) => {
+    const payload = {
+      strategy,
+      risk_level: botConfig?.risk_level || 'medium',
+      market: botConfig?.market || 'spot',
+      is_active: isActive,
+    };
+    fetch('http://localhost:8000/bot', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setBotConfig(data);
+        toast.success(isActive ? 'Strategy started' : 'Strategy stopped');
+      })
+      .catch(() => toast.error('Error updating strategy'));
+  };
+
   return (
     <main className="p-4 sm:p-6 lg:p-8">
       <div className="mb-6 px-2">
         <h2 className="text-2xl font-semibold text-gray-800 dark:text-white">Strategy Management</h2>
         <p className="text-gray-600 dark:text-gray-400">Execute available strategies.</p>
       </div>
-      <GlassCard className="max-w-md mx-auto space-y-4">
+      <GlassCard className="max-w-md mx-auto space-y-4 mb-8">
         <h3 className="text-xl font-semibold text-gray-800 dark:text-white">Test Strategy</h3>
         <input
           type="text"
@@ -79,6 +117,27 @@ export default function StrategiesPage() {
           <span>{mode === 'buy' ? 'BUY' : 'SELL'}</span>
         </button>
       </GlassCard>
+
+      <div className="space-y-4">
+        {AVAILABLE_STRATEGIES.map((s) => {
+          const active = botConfig?.is_active && botConfig?.strategy === s.id;
+          return (
+            <GlassCard key={s.id} className="flex items-center justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-800 dark:text-white">{s.name}</h3>
+                {active && <p className="text-sm text-green-500">Running</p>}
+              </div>
+              <button
+                onClick={() => updateBot(s.id, !active)}
+                className={`px-4 py-2 rounded-lg text-white font-bold flex items-center space-x-2 ${active ? 'bg-red-500 hover:bg-red-600' : 'bg-green-500 hover:bg-green-600'}`}
+              >
+                {active ? <StopCircle size={20} /> : <PlayCircle size={20} />}
+                <span>{active ? 'Stop' : 'Start'}</span>
+              </button>
+            </GlassCard>
+          );
+        })}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- implement start/stop controls for backend strategies
- show available strategies and current status on Strategies page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e16cc0ca08330b0bdd7341b1aba55