### PR TITLE
Show portfolio value toggle

### DIFF
--- a/app/assets.py
+++ b/app/assets.py
@@ -24,3 +24,32 @@ def get_assets(current_user: dict = Depends(auth.get_current_user)):
     balances = account.get("balances", [])
     non_zero = [b for b in balances if float(b.get("free", 0)) > 0 or float(b.get("locked", 0)) > 0]
     return {"balances": non_zero}
+
+
+@router.get("/portfolio_value")
+def get_portfolio_value(current_user: dict = Depends(auth.get_current_user)):
+    """Return total portfolio value in USDT."""
+    client = _get_client(current_user["id"])
+    try:
+        account = client.get_account()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    balances = account.get("balances", [])
+    total = 0.0
+    for b in balances:
+        qty = float(b.get("free", 0)) + float(b.get("locked", 0))
+        if qty <= 0:
+            continue
+        asset = b.get("asset")
+        if asset == "USDT":
+            total += qty
+            continue
+        symbol = f"{asset}USDT"
+        try:
+            ticker = client.get_symbol_ticker(symbol=symbol)
+            price = float(ticker["price"])
+            total += qty * price
+        except Exception:
+            # Skip assets without a direct USDT pair
+            continue
+    return {"total_usdt": total}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -96,6 +96,7 @@ export default function App() {
       <div className="relative z-10 min-h-screen w-full h-full">
         <Header
           theme={theme}
+          token={token}
           toggleTheme={toggleTheme}
           setPage={setPage}
           page={page}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,10 +1,44 @@
 import { Bell, Settings, User, ChevronDown, Sun, Moon, LogOut } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
-export default function Header({ theme, toggleTheme, setPage, page, onLogout, user, onOpenSettings }) {
+export default function Header({ theme, toggleTheme, setPage, page, onLogout, user, onOpenSettings, token }) {
+  const [portfolio, setPortfolio] = useState(null);
+  const [display, setDisplay] = useState('USDT');
+
+  useEffect(() => {
+    if (!token) return;
+    fetch('http://localhost:8000/portfolio_value', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then((data) => setPortfolio(data.total_usdt))
+      .catch(() => setPortfolio(null));
+  }, [token]);
+
+  const toggleDisplay = () => {
+    setDisplay((prev) => (prev === 'USDT' ? 'USD' : prev === 'USD' ? 'ZAR' : 'USDT'));
+  };
+
+  const formatValue = () => {
+    if (portfolio == null) return '...';
+    if (display === 'USDT') return `${portfolio.toFixed(2)} USDT`;
+    if (display === 'USD') return `$${portfolio.toFixed(2)}`;
+    const zarRate = 19; // simple static rate
+    return `R${(portfolio * zarRate).toFixed(2)}`;
+  };
+
   return (
     <header className="flex justify-between items-center p-4 text-gray-800 dark:text-white">
-      <div className="text-2xl font-bold tracking-wider">
-        AURA<span className="text-cyan-500 dark:text-cyan-400">BOT</span>
+      <div className="text-2xl font-bold tracking-wider flex items-center space-x-4">
+        <span>
+          AURA<span className="text-cyan-500 dark:text-cyan-400">BOT</span>
+        </span>
+        <button
+          onClick={toggleDisplay}
+          className="text-sm px-2 py-1 rounded-md bg-black/10 dark:bg-white/10 hover:bg-black/20 dark:hover:bg-white/20 transition"
+        >
+          {formatValue()}
+        </button>
       </div>
       <div className="flex items-center space-x-6">
         <div className="hidden md:flex items-center space-x-6 bg-gray-500/10 dark:bg-white/10 backdrop-blur-md rounded-full px-4 py-2 border border-gray-400/20 dark:border-white/20">


### PR DESCRIPTION
## Summary
- compute Binance portfolio value on backend
- add token prop for Header and show portfolio total next to AURABOT
- cycle display between USDT, USD and ZAR on click

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_b_687e1adeaafc8330a671226b31e08093