### PR TITLE
Fix logs page query parameter

### DIFF
--- a/frontend/src/pages/StrategyLogsPage.jsx
+++ b/frontend/src/pages/StrategyLogsPage.jsx
@@ -8,13 +8,13 @@ export default function StrategyLogsPage({ strategy, token, onBack }) {
 
   useEffect(() => {
     if (!strategy) return;
-    fetch(`http://localhost:8000/strategy/${strategy}/logs?type=detail`, {
+    fetch(`http://localhost:8000/strategy/${strategy}/logs?log_type=detail`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((res) => res.json())
       .then((data) => setDetailLogs(data.logs || []))
       .catch(() => setDetailLogs([]));
-    fetch(`http://localhost:8000/strategy/${strategy}/logs?type=trade`, {
+    fetch(`http://localhost:8000/strategy/${strategy}/logs?log_type=trade`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((res) => res.json())


### PR DESCRIPTION
## Summary
- fix query parameter name in StrategyLogsPage for log retrieval

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687e35931ab0832c9649cd7ceaf00073