### PR TITLE
Add strategy run trigger and logging

### DIFF
--- a/app/strategies.py
+++ b/app/strategies.py
@@ -113,6 +113,7 @@ def run_strategy(
 ):
     """Execute a single evaluation of the strategy and log the steps."""
     client = _get_client(current_user["id"])
+    _log(strategy_id, f"Strategy started with amount {amount}")
     if strategy_id == "squeeze_breakout":
         if not symbol:
             raise HTTPException(status_code=400, detail="symbol required")

--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -85,6 +85,18 @@ export default function StrategiesPage({ setPage, setLogStrategy }) {
       .then((data) => {
         setBotConfig(data);
         toast.success(isActive ? 'Strategy started' : 'Strategy stopped');
+        if (isActive) {
+          fetch(`http://localhost:8000/strategy/${strategy}/run`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ amount: payload.amount }),
+          })
+            .then((r) => (r.ok ? r.json() : null))
+            .catch(() => {});
+        }
       })
       .catch(() => toast.error('Error updating strategy'));
   };


### PR DESCRIPTION
## Summary
- log strategy start with amount
- trigger strategy run when activating a strategy from UI

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687e3a2f1408832cb9961eb5c6e1458b