### PR TITLE
Enhance strategy logs UI

### DIFF
--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -6,6 +6,7 @@ import { toast } from 'react-hot-toast';
 const AVAILABLE_STRATEGIES = [
   { id: 'squeeze_breakout', name: 'Squeeze Breakout' },
   { id: 'squeeze_breakout_doge_1h', name: 'DOGEUSDT 1H Squeeze Breakout' },
+  { id: 'squeeze_breakout_sol_4h', name: 'SOLUSDT 4H Squeeze Breakout' },
 ];
 
 export default function StrategiesPage({ setPage, setLogStrategy }) {

--- a/frontend/src/pages/StrategyLogsPage.jsx
+++ b/frontend/src/pages/StrategyLogsPage.jsx
@@ -8,18 +8,25 @@ export default function StrategyLogsPage({ strategy, token, onBack }) {
 
   useEffect(() => {
     if (!strategy) return;
-    fetch(`http://localhost:8000/strategy/${strategy}/logs?log_type=detail`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-      .then((res) => res.json())
-      .then((data) => setDetailLogs(data.logs || []))
-      .catch(() => setDetailLogs([]));
-    fetch(`http://localhost:8000/strategy/${strategy}/logs?log_type=trade`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-      .then((res) => res.json())
-      .then((data) => setTradeLogs(data.logs || []))
-      .catch(() => setTradeLogs([]));
+
+    const fetchLogs = () => {
+      fetch(`http://localhost:8000/strategy/${strategy}/logs?log_type=detail`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => setDetailLogs(data.logs || []))
+        .catch(() => {});
+      fetch(`http://localhost:8000/strategy/${strategy}/logs?log_type=trade`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => setTradeLogs(data.logs || []))
+        .catch(() => {});
+    };
+
+    fetchLogs();
+    const id = setInterval(fetchLogs, 2000);
+    return () => clearInterval(id);
   }, [strategy, token]);
 
   const activeClass =


### PR DESCRIPTION
## Summary
- display SOLUSDT strategy in the strategies list
- auto-refresh strategy logs so they update while viewing

## Testing
- `pytest -q`
- `npm test --silent` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_687e3d572700832c8bc6581e810e6e9e