### PR TITLE
Fix logs visibility for both themes

### DIFF
--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -218,7 +218,7 @@ export default function StrategiesPage({ setPage, setLogStrategy }) {
         </GlassCard>
         <GlassCard className="space-y-4">
           <h3 className="text-xl font-semibold text-gray-800 dark:text-white">Trade Logs</h3>
-          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto">
+          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto text-gray-800 dark:text-gray-200">
             {tradeLogs.map((l, i) => (
               <div key={i}>{l}</div>
             ))}

--- a/frontend/src/pages/StrategyLogsPage.jsx
+++ b/frontend/src/pages/StrategyLogsPage.jsx
@@ -53,13 +53,13 @@ export default function StrategyLogsPage({ strategy, token, onBack }) {
           </button>
         </div>
         {tab === 'detail' ? (
-          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto">
+          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto text-gray-800 dark:text-gray-200">
             {detailLogs.map((l, i) => (
               <div key={i}>{l}</div>
             ))}
           </div>
         ) : (
-          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto">
+          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto text-gray-800 dark:text-gray-200">
             {tradeLogs.map((t, i) => (
               <div key={i}>{t}</div>
             ))}


### PR DESCRIPTION
## Summary
- ensure log text uses contrasting colors in light and dark modes

## Testing
- `npm run build` *(fails: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687f1e5204548330b97f95546d74a96d