### PR TITLE
Improve trade logs with strategy info and colors

### DIFF
--- a/app/strategies.py
+++ b/app/strategies.py
@@ -550,6 +550,7 @@ async def _run_strategy_loop(
         "continuous_trend_rider_xrp_1m": ("XRPUSDT", Client.KLINE_INTERVAL_1MINUTE),
     }
     symbol, interval = symbol_map[strategy_id]
+    strategy_name = AVAILABLE_STRATEGIES.get(strategy_id, strategy_id)
     limit = strategy.ema_length + strategy.squeeze_length + 50
     key = (user_id, strategy_id)
     token = current_user_ctx.set(user_id)
@@ -587,7 +588,9 @@ async def _run_strategy_loop(
                     f"BUY {symbol} @ {price}"
                 )
                 logs = GLOBAL_TRADE_LOGS.setdefault(user_id, [])
-                logs.append(f"BUY {symbol} @ {price}")
+                logs.append(
+                    f"{strategy_name}: BUY {symbol} @ {price}"
+                )
                 if len(logs) > 1000:
                     logs.pop(0)
             elif signal == "SELL" and OPEN_POSITION.get(key) is not None:
@@ -602,7 +605,9 @@ async def _run_strategy_loop(
                 profit = price - entry
                 pct = (profit / entry) * 100 if entry else 0.0
                 logs = GLOBAL_TRADE_LOGS.setdefault(user_id, [])
-                logs.append(f"SELL {symbol} @ {price} ({pct:.2f}% profit)")
+                logs.append(
+                    f"{strategy_name}: SELL {symbol} @ {price} ({pct:.2f}% profit)"
+                )
                 if len(logs) > 1000:
                     logs.pop(0)
                 log_detail(

--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -218,10 +218,24 @@ export default function StrategiesPage({ setPage, setLogStrategy }) {
         </GlassCard>
         <GlassCard className="space-y-4">
           <h3 className="text-xl font-semibold text-gray-800 dark:text-white">Trade Logs</h3>
-          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto text-gray-800 dark:text-gray-200">
-            {tradeLogs.map((l, i) => (
-              <div key={i}>{l}</div>
-            ))}
+          <div className="space-y-1 text-sm font-mono whitespace-pre-wrap max-h-96 overflow-y-auto">
+            {tradeLogs.map((l, i) => {
+              let color = 'text-gray-800 dark:text-gray-200';
+              if (l.includes('SELL')) {
+                const m = l.match(/([-\d.]+)% profit/);
+                if (m) {
+                  const pct = parseFloat(m[1]);
+                  color = pct >= 0 ? 'text-green-600' : 'text-red-600';
+                }
+              } else if (l.includes('BUY')) {
+                color = 'text-blue-600';
+              }
+              return (
+                <div key={i} className={color}>
+                  {l}
+                </div>
+              );
+            })}
           </div>
         </GlassCard>
       </div>


### PR DESCRIPTION
## Summary
- tag each trade log with the strategy name on the backend
- display trade logs in different colors depending on profit or loss

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687f66edab50832c835ec34368355de4