### PR TITLE
Fix profit calculation with whitespace

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -23,8 +23,9 @@ def _compute_metrics(trades):
     durations = []
 
     for trade in trades_sorted:
-        symbol = trade.get("symbol")
-        side = (trade.get("side") or "").upper()
+        # handle potential whitespace or mixed case values from the database
+        symbol = (trade.get("symbol") or "").strip()
+        side = (trade.get("side") or "").strip().upper()
         quantity = float(trade.get("quantity", 0))
         price = float(trade.get("price", 0))
         trade_id = trade.get("id")


### PR DESCRIPTION
## Summary
- trim whitespace from `symbol` and `side` fields in dashboard calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fa960b7608330b96ea7807e98ca83