### PR TITLE
Add total profit tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project contains a simple FastAPI backend for a crypto and stock trading bo
    the dependencies. The file pins `numpy<2.0` for compatibility and includes
    basic indicator helpers so no external `pandas-ta` package is required.
 2. Create a project in [Supabase](https://supabase.com) and create the following tables:
-   - `users` and `trades` matching the models in `app/schemas.py`.
+   - `users` and `trades` matching the models in `app/schemas.py` (be sure the `users` table includes a `total_profit` numeric column with a default of `0`).
    - `user_settings` using the SQL below.
 3. Grab your project API URL and service role key from the Supabase dashboard and set them as environment variables:
    ```bash
@@ -56,4 +56,10 @@ create table if not exists user_strategy_runs (
 create unique index if not exists user_strategy_active_idx
   on user_strategy_runs(user_id, strategy_id)
   where is_running is true;
+```
+
+To store the cumulative profit for each user, add a `total_profit` column to the `users` table:
+
+```sql
+alter table users add column if not exists total_profit numeric default 0;
 ```

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -25,6 +25,7 @@ class UserCreate(UserBase):
 class User(UserBase):
     id: int
     status: str
+    total_profit: float = 0.0
     trades: List[Trade] = []
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/supabase_db.py
+++ b/app/supabase_db.py
@@ -60,7 +60,12 @@ class SupabaseDB:
 
     # User operations
     def create_user(self, username: str, hashed_password: str, status: str = "Pending"):
-        data = {"username": username, "hashed_password": hashed_password, "status": status}
+        data = {
+            "username": username,
+            "hashed_password": hashed_password,
+            "status": status,
+            "total_profit": 0.0,
+        }
         res = self._request("POST", "/users", data=data)
         return res[0] if res else None
 
@@ -80,6 +85,12 @@ class SupabaseDB:
     def update_user_status(self, user_id: int, status: str):
         params = {"id": f"eq.{user_id}"}
         data = {"status": status}
+        res = self._request("PATCH", "/users", params=params, data=data)
+        return res[0] if res else None
+
+    def update_user_total_profit(self, user_id: int, total_profit: float):
+        params = {"id": f"eq.{user_id}"}
+        data = {"total_profit": total_profit}
         res = self._request("PATCH", "/users", params=params, data=data)
         return res[0] if res else None
 


### PR DESCRIPTION
## Summary
- persist total profit per user on Supabase
- expose profit on dashboard endpoint
- document SQL to add `total_profit` column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fb2c8590483309ff3ce0f2d697495