### PR TITLE
Update total profit after trades

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -1,12 +1,20 @@
 from fastapi import HTTPException
 from . import schemas
 from .supabase_db import db
+from .dashboard import _compute_metrics
 
 
 def create_trade(trade: schemas.TradeCreate, user_id: int):
     data = trade.dict()
     data["owner_id"] = user_id
-    return db.create_trade(data)
+    new_trade = db.create_trade(data)
+    try:
+        # recompute user's total profit whenever a new trade is recorded
+        trades = db.get_trades(user_id, skip=0, limit=1000) or []
+        _compute_metrics(user_id, trades)
+    except Exception:
+        pass
+    return new_trade
 
 
 def get_trade(trade_id: int):
@@ -23,10 +31,22 @@ def get_trades(owner_id: int, skip: int = 0, limit: int = 100):
 def update_trade(trade_id: int, trade: schemas.TradeCreate):
     existing = get_trade(trade_id)
     data = trade.dict()
-    return db.update_trade(trade_id, data)
+    updated = db.update_trade(trade_id, data)
+    try:
+        # update cached metrics after trade modifications
+        trades = db.get_trades(existing["owner_id"], skip=0, limit=1000) or []
+        _compute_metrics(existing["owner_id"], trades)
+    except Exception:
+        pass
+    return updated
 
 
 def delete_trade(trade_id: int):
     existing = get_trade(trade_id)
     db.delete_trade(trade_id)
+    try:
+        trades = db.get_trades(existing["owner_id"], skip=0, limit=1000) or []
+        _compute_metrics(existing["owner_id"], trades)
+    except Exception:
+        pass
     return existing


### PR DESCRIPTION
## Summary
- ensure the API recomputes metrics when trades are created, updated, or deleted
- keep user `total_profit` in sync by calling `_compute_metrics`

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687fba7fb1088330a1a196f7fbdf9ac5