### PR TITLE
Enable real trading on Binance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This project contains a simple FastAPI backend for a crypto and stock trading bo
    uvicorn app.main:app --reload
    ```
 
+When a strategy is started it will place real market orders on Binance using the
+API keys configured for the user. Ensure the keys have trading permissions and
+exercise caution as real funds are at risk.
+
 The API documentation is available at `/docs` when the server is running.
 
 ## Supabase SQL


### PR DESCRIPTION
## Summary
- strategies now place real market orders through the Binance API
- document in README that strategies execute real trades when started

## Testing
- `python -m py_compile app/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fcb56683883308cd652d64c7f2304