### PR TITLE
Ensure bot trades saved

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -6,6 +6,11 @@ class TradeBase(BaseModel):
     side: str
     quantity: float
     price: float
+    # Optional fields used when a trade is created programmatically by a
+    # strategy.  These map directly to columns in the ``trades`` table.
+    strategy_id: Optional[str] = None
+    status: Optional[str] = None
+    related_trade_id: Optional[int] = None
 
 class TradeCreate(TradeBase):
     pass


### PR DESCRIPTION
## Summary
- extend `TradeBase` to allow strategy metadata
- track trade ID in `Position`
- insert buy and sell orders into `trades` table and link them when strategies run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b0d9ef168832cbbbbf03679eb8f08