### PR TITLE
Add charts page with safe number formatting

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import UserManagementPage from './pages/UserManagementPage';
 import StrategiesPage from './pages/StrategiesPage';
 import StrategyLogsPage from './pages/StrategyLogsPage';
 import AssetsPage from './pages/AssetsPage';
+import ChartsPage from './pages/ChartsPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import { Toaster } from 'react-hot-toast';
@@ -76,6 +77,8 @@ export default function App() {
         );
       case 'assets':
         return <AssetsPage />;
+      case 'charts':
+        return <ChartsPage token={token} />;
       default:
         return <DashboardPage theme={theme} token={token} />;
     }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -80,8 +80,14 @@ export default function Header({ theme, toggleTheme, setPage, page, onLogout, us
           >
             Assets
           </a>
-          <a href="#" className="hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors">
-            Analytics
+          <a
+            href="#"
+            onClick={() => setPage('charts')}
+            className={`${
+              page === 'charts' ? 'text-cyan-600 dark:text-cyan-400' : ''
+            } hover:text-cyan-600 dark:hover:text-cyan-400 transition-colors`}
+          >
+            Charts
           </a>
         </div>
       </nav>

--- a/frontend/src/pages/ChartsPage.jsx
+++ b/frontend/src/pages/ChartsPage.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import GlassCard from '../components/GlassCard';
+
+const formatNum = (n) => (typeof n === 'number' ? n.toLocaleString() : 'N/A');
+
+function MarketInfo({ data }) {
+  if (!data) return null;
+  return (
+    <GlassCard className="mb-6">
+      <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Market Info</h3>
+      <div className="grid grid-cols-2 gap-4 text-gray-700 dark:text-gray-200">
+        <div>
+          <p className="text-sm text-gray-500">Symbol</p>
+          <p className="font-semibold">{data.symbol || 'N/A'}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-gray-500">Price</p>
+          <p className="font-semibold">${formatNum(data.price)}</p>
+        </div>
+        <div>
+          <p className="text-sm text-gray-500">Volume</p>
+          <p className="font-semibold">{formatNum(data.volume)}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-gray-500">Change 24h</p>
+          <p className="font-semibold">{formatNum(data.change_24h)}</p>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+export default function ChartsPage({ token }) {
+  const [info, setInfo] = useState(null);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch('http://localhost:8000/dashboard', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then((data) => setInfo(data.stats))
+      .catch(() => setInfo(null));
+  }, [token]);
+
+  return (
+    <main className="p-4 sm:p-6 lg:p-8">
+      <MarketInfo data={info} />
+      {/* Placeholder for future chart implementation */}
+      <GlassCard className="h-64 flex items-center justify-center text-gray-500">
+        Charts coming soon
+      </GlassCard>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `ChartsPage` with defensive `toLocaleString` usage
- hook Charts page into the app and header navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b3622942083308e71e4ec5e807ceb