### PR TITLE
Fix charts page disposal issues

### DIFF
--- a/frontend/src/pages/ChartsPage.jsx
+++ b/frontend/src/pages/ChartsPage.jsx
@@ -88,6 +88,10 @@ export default function ChartsPage({ theme }) {
     return () => {
       window.removeEventListener('resize', handleResize);
       chart.remove();
+      chartInstance.current = null;
+      lineSeries.current = null;
+      candleSeries.current = null;
+      volumeSeries.current = null;
     };
   }, [theme, chartType]);
 
@@ -101,6 +105,7 @@ export default function ChartsPage({ theme }) {
       const candles = kRes.map(k => ({ time: k[0] / 1000, open: +k[1], high: +k[2], low: +k[3], close: +k[4] }));
       const volumes = kRes.map(k => ({ time: k[0] / 1000, value: +k[5], color: +k[4] >= +k[1] ? '#16a34a' : '#dc2626' }));
       const line = kRes.map(k => ({ time: k[0] / 1000, value: +k[4] }));
+      if (!lineSeries.current || !candleSeries.current || !volumeSeries.current || !chartInstance.current) return;
       candleSeries.current.setData(candles);
       lineSeries.current.setData(line);
       volumeSeries.current.setData(volumes);
@@ -111,7 +116,9 @@ export default function ChartsPage({ theme }) {
         low: +tRes.lowPrice,
         volume: +tRes.volume,
       });
-      chartInstance.current.timeScale().fitContent();
+      if (chartInstance.current) {
+        chartInstance.current.timeScale().fitContent();
+      }
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Summary
- fix disposed object errors on ChartsPage by nulling chart refs on cleanup
- guard against updates when chart is removed

## Testing
- `python -m compileall -q app frontend/src`
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b4a053d3c8330867dda55727a6b26