### PR TITLE
Improve responsive layout

### DIFF
--- a/frontend/src/components/GlassCard.jsx
+++ b/frontend/src/components/GlassCard.jsx
@@ -1,7 +1,7 @@
 export default function GlassCard({ children, className = '' }) {
   return (
     <div
-      className={`backdrop-blur-lg rounded-2xl shadow-lg p-6 transition-all duration-300 bg-gray-500/10 dark:bg-white/20 border border-gray-400/20 dark:border-white/20 ${className}`}
+      className={`backdrop-blur-lg rounded-2xl shadow-lg p-4 sm:p-6 transition-all duration-300 bg-gray-500/10 dark:bg-white/20 border border-gray-400/20 dark:border-white/20 ${className}`}
     >
       {children}
     </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -32,7 +32,7 @@ export default function Header({ theme, toggleTheme, setPage, page, onLogout, us
     <header
       className="sticky top-0 z-20 flex items-center p-4 text-gray-800 dark:text-white bg-white/70 dark:bg-gray-900/50 backdrop-blur-md border-b border-gray-200 dark:border-gray-700 shadow relative"
     >
-      <div className="flex-1 text-2xl font-bold tracking-wider flex items-center space-x-4">
+      <div className="flex-1 text-xl sm:text-2xl font-bold tracking-wider flex items-center space-x-4">
         <span>
           AURA<span className="text-cyan-500 dark:text-cyan-400">BOT</span>
         </span>

--- a/frontend/src/components/LogModal.jsx
+++ b/frontend/src/components/LogModal.jsx
@@ -37,7 +37,7 @@ export default function LogModal({ strategy, token, onClose }) {
     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-50 flex items-center justify-center p-4">
       <GlassCard className="w-full max-w-4xl h-[80vh] flex flex-col">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-2xl font-semibold text-gray-800 dark:text-white">Logs: {strategy.name}</h2>
+          <h2 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-white">Logs: {strategy.name}</h2>
           <button onClick={onClose} className="p-2 rounded-full text-gray-800 dark:text-white hover:bg-black/10 dark:hover:bg-white/20">✕</button>
         </div>
         <div className="flex border-b border-gray-400/20 dark:border-white/20 mb-4">

--- a/frontend/src/components/SettingsModal.jsx
+++ b/frontend/src/components/SettingsModal.jsx
@@ -44,7 +44,7 @@ export default function SettingsModal({ visible, onClose, token }) {
   return (
     <div className={`fixed inset-0 flex items-center justify-center bg-black/50 ${show}`}>
       <div className="bg-white dark:bg-gray-800 p-6 rounded shadow w-full max-w-md">
-        <h2 className="text-xl font-semibold mb-4 text-gray-800 dark:text-white">Settings</h2>
+        <h2 className="text-lg sm:text-xl font-semibold mb-4 text-gray-800 dark:text-white">Settings</h2>
         <div className="mb-3">
           <label className="block text-sm mb-1 text-gray-700 dark:text-gray-300">Binance API Key</label>
           <input

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,3 +6,19 @@ body {
   margin: 0;
   font-family: system-ui, sans-serif;
 }
+
+html {
+  font-size: 16px;
+}
+
+@media (max-width: 640px) {
+  html {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  html {
+    font-size: 12px;
+  }
+}

--- a/frontend/src/pages/AssetsPage.jsx
+++ b/frontend/src/pages/AssetsPage.jsx
@@ -21,7 +21,7 @@ export default function AssetsPage() {
   return (
     <main className="p-4 sm:p-6 lg:p-8">
       <GlassCard>
-        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Binance Assets</h3>
+        <h3 className="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white mb-4">Binance Assets</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-left text-gray-600 dark:text-gray-300">
             <thead className="border-b border-gray-400/20 dark:border-white/20">

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -21,7 +21,7 @@ const StatCard = ({ icon, title, value, change, changeType }) => {
         <div className="p-3 bg-black/5 dark:bg-white/10 rounded-full border border-black/10 dark:border-white/20">{icon}</div>
         <div>
           <p className="text-gray-600 dark:text-gray-300 text-sm">{title}</p>
-          <p className="text-2xl font-semibold text-gray-800 dark:text-white">{value}</p>
+          <p className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-white">{value}</p>
           {change && <p className={`text-sm ${changeColor}`}>{change}</p>}
         </div>
       </div>
@@ -36,7 +36,7 @@ const MainChart = ({ theme, data }) => {
     <GlassCard className="col-span-12 lg:col-span-8 h-[450px] flex flex-col">
       <div className="flex justify-between items-start mb-4">
         <div>
-          <h3 className="text-xl font-semibold text-gray-800 dark:text-white">Performance Overview</h3>
+          <h3 className="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white">Performance Overview</h3>
           <p className="text-gray-600 dark:text-gray-400">Last 24 hours</p>
         </div>
         <div className="flex space-x-2">
@@ -103,7 +103,7 @@ const BotControl = ({ token }) => {
   return (
     <GlassCard className="col-span-12 lg:col-span-4 h-full flex flex-col justify-between">
       <div>
-        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Bot Control</h3>
+        <h3 className="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white mb-4">Bot Control</h3>
         <div className="flex items-center justify-between mb-4">
           <span className="text-gray-600 dark:text-gray-300">Status</span>
           <div className={`flex items-center space-x-2 px-3 py-1 rounded-full text-sm ${isBotActive ? 'bg-green-500/30 text-green-300' : 'bg-red-500/30 text-red-300'}`}>
@@ -131,7 +131,7 @@ const BotControl = ({ token }) => {
 
 const TradeHistoryTable = ({ tradeHistory }) => (
   <GlassCard className="col-span-12">
-    <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Trade History</h3>
+    <h3 className="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white mb-4">Trade History</h3>
     <div className="overflow-x-auto">
       <table className="w-full text-left text-gray-600 dark:text-gray-300">
         <thead className="border-b border-gray-400/20 dark:border-white/20">

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -31,7 +31,7 @@ export default function LoginPage({ onLogin, theme, goToRegister }) {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
       <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-8 rounded shadow-md w-full max-w-xs">
-        <h2 className="text-2xl mb-4 text-center text-gray-800 dark:text-gray-100">Login</h2>
+        <h2 className="text-xl sm:text-2xl mb-4 text-center text-gray-800 dark:text-gray-100">Login</h2>
         {error && <p className="text-red-500 mb-2">{error}</p>}
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Username</label>

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -31,7 +31,7 @@ export default function RegisterPage({ onRegistered, goToLogin }) {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
       <form onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-8 rounded shadow-md w-full max-w-xs">
-        <h2 className="text-2xl mb-4 text-center text-gray-800 dark:text-gray-100">Register</h2>
+        <h2 className="text-xl sm:text-2xl mb-4 text-center text-gray-800 dark:text-gray-100">Register</h2>
         {error && <p className="text-red-500 mb-2">{error}</p>}
         {success && <p className="text-green-500 mb-2">Registration successful!</p>}
         <div className="mb-4">

--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -102,7 +102,7 @@ export default function StrategiesPage() {
   return (
     <main className="p-4 sm:p-6 lg:p-8">
       <div className="mb-6 px-2">
-        <h2 className="text-2xl font-semibold text-gray-800 dark:text-white">Strategy Management</h2>
+        <h2 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-white">Strategy Management</h2>
         <p className="text-gray-600 dark:text-gray-400">Execute available strategies.</p>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
@@ -112,7 +112,7 @@ export default function StrategiesPage() {
           return (
             <GlassCard key={s.id}>
               <div className="flex justify-between items-start">
-                <h3 className="text-xl font-semibold text-gray-800 dark:text-white">{s.name}</h3>
+                <h3 className="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white">{s.name}</h3>
                 <span className={`px-3 py-1 text-xs rounded-full ${s.running ? 'bg-green-500/20 text-green-100' : 'bg-gray-500/20 text-gray-100'}`}>{status}</span>
               </div>
               <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">{info.description}</p>

--- a/frontend/src/pages/UserManagementPage.jsx
+++ b/frontend/src/pages/UserManagementPage.jsx
@@ -42,7 +42,7 @@ export default function UserManagementPage() {
   return (
     <main className="p-4 sm:p-6 lg:p-8">
       <div className="flex justify-between items-center mb-6 px-2">
-        <h2 className="text-2xl font-semibold text-gray-800 dark:text-white">User Administration</h2>
+        <h2 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-white">User Administration</h2>
         <div className="relative">
           <input
             type="text"
@@ -56,7 +56,7 @@ export default function UserManagementPage() {
       </div>
 
       <GlassCard className="mb-8">
-        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Pending Approval ({pendingUsers.length})</h3>
+        <h3 className="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white mb-4">Pending Approval ({pendingUsers.length})</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-left text-gray-600 dark:text-gray-300">
             <thead className="border-b border-gray-400/20 dark:border-white/20">
@@ -93,7 +93,7 @@ export default function UserManagementPage() {
       </GlassCard>
 
       <GlassCard>
-        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">User Management</h3>
+        <h3 className="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white mb-4">User Management</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-left text-gray-600 dark:text-gray-300">
             <thead className="border-b border-gray-400/20 dark:border-white/20">


### PR DESCRIPTION
## Summary
- tweak GlassCard padding for mobile
- adjust heading sizes across pages
- add responsive base font scaling

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b656f9fdc83309fc34d56c8dbf859