### PR TITLE
Update trade history to use summary view

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -12,8 +12,7 @@ def create_trade(trade: schemas.TradeCreate, user_id: int):
     new_trade = db.create_trade(data)
     try:
         # recompute user's total profit whenever a new trade is recorded
-        trades = db.get_trades(user_id, skip=0, limit=1000) or []
-        _compute_metrics(user_id, trades)
+        _compute_metrics(user_id)
     except Exception:
         pass
     return new_trade
@@ -38,8 +37,7 @@ def update_trade(trade_id: int, trade: schemas.TradeCreate):
     updated = db.update_trade(trade_id, data)
     try:
         # update cached metrics after trade modifications
-        trades = db.get_trades(existing["owner_id"], skip=0, limit=1000) or []
-        _compute_metrics(existing["owner_id"], trades)
+        _compute_metrics(existing["owner_id"])
     except Exception:
         pass
     return updated
@@ -49,8 +47,7 @@ def delete_trade(trade_id: int):
     existing = get_trade(trade_id)
     db.delete_trade(trade_id)
     try:
-        trades = db.get_trades(existing["owner_id"], skip=0, limit=1000) or []
-        _compute_metrics(existing["owner_id"], trades)
+        _compute_metrics(existing["owner_id"])
     except Exception:
         pass
     return existing

--- a/app/supabase_db.py
+++ b/app/supabase_db.py
@@ -112,6 +112,15 @@ class SupabaseDB:
         }
         return self._request("GET", "/trades", params=params)
 
+    def get_trade_summary(self, owner_id: int, skip: int = 0, limit: int = 100):
+        """Return rows from the ``trade_summary_view`` for a user."""
+        params = {
+            "owner_id": f"eq.{owner_id}",
+            "offset": skip,
+            "limit": limit,
+        }
+        return self._request("GET", "/trade_summary_view", params=params)
+
     def update_trade(self, trade_id: int, trade: dict):
         params = {"id": f"eq.{trade_id}"}
         res = self._request("PATCH", "/trades", params=params, data=trade)

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -138,9 +138,10 @@ const TradeHistoryTable = ({ tradeHistory }) => (
           <tr>
             <th className="p-3">ID</th>
             <th className="p-3">Pair</th>
-            <th className="p-3">Type</th>
+            <th className="p-3">Strategy</th>
             <th className="p-3">Status</th>
-            <th className="p-3 text-right">Profit/Loss</th>
+            <th className="p-3 text-right">Profit %</th>
+            <th className="p-3 text-right">Profit $</th>
           </tr>
         </thead>
         <tbody>
@@ -148,9 +149,10 @@ const TradeHistoryTable = ({ tradeHistory }) => (
             <tr key={trade.id} className="border-b border-gray-400/10 dark:border-white/10 hover:bg-black/5 dark:hover:bg-white/5 transition-colors">
               <td className="p-3 font-mono text-xs">{trade.id}</td>
               <td className="p-3 font-semibold text-gray-800 dark:text-white">{trade.pair}</td>
-              <td className={`p-3 font-bold ${trade.type === 'BUY' ? 'text-cyan-500 dark:text-cyan-400' : 'text-fuchsia-500 dark:text-fuchsia-400'}`}>{trade.type}</td>
+              <td className="p-3">{trade.strategy}</td>
               <td className="p-3"><span className={`px-2 py-1 text-xs rounded-full ${trade.status === 'Open' ? 'bg-yellow-500/20 text-yellow-300' : 'bg-gray-500/20 text-gray-300'}`}>{trade.status}</span></td>
-              <td className={`p-3 text-right font-semibold ${trade.profit >= 0 ? 'text-green-500 dark:text-green-400' : 'text-red-400'}`}>{trade.profit >= 0 ? `+$${trade.profit.toFixed(2)}` : `-$${Math.abs(trade.profit).toFixed(2)}`}</td>
+              <td className="p-3 text-right font-semibold">{trade.profit_percentage.toFixed(2)}%</td>
+              <td className={`p-3 text-right font-semibold ${trade.profit >= 0 ? 'text-green-500 dark:text-green-400' : 'text-red-400'}`}>${trade.profit.toFixed(2)}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- fetch new `trade_summary_view` in backend to combine finished trades
- expose open trade info and compute stats accordingly
- update dashboard trade history table to show strategy and profit columns

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_b_688b79773cd4832c8a9a89faf80cdf70