### PR TITLE
feat: add refresh tokens and sliding session

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 import os
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Body
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -13,6 +13,7 @@ from .supabase_db import db
 SECRET_KEY = os.getenv("SECRET_KEY", "CHANGE_ME")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
+REFRESH_TOKEN_EXPIRE_DAYS = 7
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
@@ -47,6 +48,10 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
+
+def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None):
+    return create_access_token(data, expires_delta)
+
 # Routes
 
 @router.post("/register", response_model=schemas.User)
@@ -73,10 +78,45 @@ def login(form_data: OAuth2PasswordRequestForm = Depends()):
             detail="User not approved",
         )
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    refresh_token_expires = timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     access_token = create_access_token(
         data={"sub": user["username"]}, expires_delta=access_token_expires
     )
-    return {"access_token": access_token, "token_type": "bearer"}
+    refresh_token = create_refresh_token(
+        data={"sub": user["username"]}, expires_delta=refresh_token_expires
+    )
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }
+
+
+@router.post("/token/refresh")
+def refresh_token(refresh_token: str = Body(..., embed=True)):
+    try:
+        payload = jwt.decode(refresh_token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+    user = get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    refresh_token_expires = timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    new_access = create_access_token(
+        data={"sub": username}, expires_delta=access_token_expires
+    )
+    new_refresh = create_refresh_token(
+        data={"sub": username}, expires_delta=refresh_token_expires
+    )
+    return {
+        "access_token": new_access,
+        "refresh_token": new_refresh,
+        "token_type": "bearer",
+    }
 
 
 def get_current_user(token: str = Depends(oauth2_scheme)):

--- a/app/strategies.py
+++ b/app/strategies.py
@@ -5,6 +5,9 @@ import asyncio
 from datetime import datetime
 from contextvars import ContextVar
 from dataclasses import dataclass
+import time
+
+from jose import jwt
 
 from . import auth
 from .supabase_db import db
@@ -121,6 +124,7 @@ def atr(df: pd.DataFrame, length: int) -> pd.Series:
 
 # --- RUNNING STRATEGIES ---
 # keep track of running background tasks and trade history
+# Each task stores metadata including tokens for refreshing credentials
 RUNNING_TASKS: dict[tuple[int, str], dict] = {}
 
 # track the currently open position for each user/strategy.  None indicates no
@@ -607,6 +611,27 @@ def get_all_trade_logs(current_user: dict = Depends(auth.get_current_user)):
     return {"logs": GLOBAL_TRADE_LOGS.get(current_user["id"], [])}
 
 
+def _ensure_strategy_tokens(key: tuple[int, str]) -> None:
+    """Refresh the stored access token for a running strategy if needed."""
+    data = RUNNING_TASKS.get(key)
+    if not data:
+        return
+    refresh = data.get("refresh_token")
+    exp = data.get("expires", 0)
+    if not refresh:
+        return
+    # if the access token is expiring within the next minute, refresh it
+    if exp - time.time() > 60:
+        return
+    refreshed = auth.refresh_token(refresh_token=refresh)
+    data["access_token"] = refreshed["access_token"]
+    data["refresh_token"] = refreshed["refresh_token"]
+    payload = jwt.decode(
+        refreshed["access_token"], auth.SECRET_KEY, algorithms=[auth.ALGORITHM]
+    )
+    data["expires"] = payload.get("exp", 0)
+
+
 async def _run_strategy_loop(
     strategy,
     client,
@@ -636,6 +661,7 @@ async def _run_strategy_loop(
     token = current_user_ctx.set(user_id)
 
     while True:
+        _ensure_strategy_tokens(key)
         try:
             klines = client.get_klines(symbol=symbol, interval=interval, limit=limit)
             if not klines:
@@ -770,6 +796,8 @@ async def start_strategy(
     strategy_id: str,
     amount: float | None = Body(None, embed=True),
     current_user: dict = Depends(auth.get_current_user),
+    token: str = Depends(auth.oauth2_scheme),
+    refresh_token: str | None = Body(None, embed=True),
 ):
     strategy_id = strategy_id.lower()
     key = (current_user["id"], strategy_id)
@@ -787,7 +815,15 @@ async def start_strategy(
     task = asyncio.create_task(
         _run_strategy_loop(strategy, client, current_user["id"], strategy_id, amount)
     )
-    RUNNING_TASKS[key] = {"task": task, "run_id": run["id"], "amount": amount}
+    exp_payload = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+    RUNNING_TASKS[key] = {
+        "task": task,
+        "run_id": run["id"],
+        "amount": amount,
+        "access_token": token,
+        "refresh_token": refresh_token,
+        "expires": exp_payload.get("exp", 0),
+    }
     OPEN_POSITION.setdefault(key, None)
     TRADE_HISTORY.setdefault(key, [])
     token = current_user_ctx.set(current_user["id"])

--- a/app/strategies.py
+++ b/app/strategies.py
@@ -7,7 +7,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 import time
 
-from jose import jwt
+from jose import jwt, JWTError
 
 from . import auth
 from .supabase_db import db
@@ -806,6 +806,15 @@ async def start_strategy(
     existing = db.get_active_user_strategy(current_user["id"], strategy_id)
     if existing:
         raise HTTPException(status_code=400, detail="Strategy already running")
+    if refresh_token is None:
+        raise HTTPException(status_code=400, detail="refresh_token is required")
+    try:
+        payload = jwt.decode(refresh_token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+        username = payload.get("sub")
+        if username != current_user["username"]:
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
     cls = STRATEGY_CLASSES.get(strategy_id)
     if not cls:
         raise HTTPException(status_code=404, detail="Unknown strategy")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ export default function App() {
   const [page, setPage] = useState('dashboard');
   const [authPage, setAuthPage] = useState('login');
   const [token, setToken] = useState(localStorage.getItem('token'));
+  const [refreshToken, setRefreshToken] = useState(localStorage.getItem('refresh_token'));
   const [user, setUser] = useState(null);
   const [showSettings, setShowSettings] = useState(false);
   const [logStrategy, setLogStrategy] = useState(null);
@@ -36,27 +37,77 @@ export default function App() {
         headers: { Authorization: `Bearer ${token}` },
       })
         .then((res) => {
+          if (res.status === 401 && refreshToken) {
+            return fetch('http://localhost:8000/token/refresh', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ refresh_token: refreshToken }),
+            })
+              .then((r) => {
+                if (!r.ok) throw new Error('refresh_failed');
+                return r.json();
+              })
+              .then((data) => {
+                localStorage.setItem('token', data.access_token);
+                localStorage.setItem('refresh_token', data.refresh_token);
+                setToken(data.access_token);
+                setRefreshToken(data.refresh_token);
+                return fetch('http://localhost:8000/users/me', {
+                  headers: { Authorization: `Bearer ${data.access_token}` },
+                });
+              });
+          }
           if (!res.ok) throw new Error('unauthorized');
-          return res.json();
+          return res;
         })
+        .then((res) => res.json())
         .then((data) => setUser(data))
         .catch(() => {
           localStorage.removeItem('token');
+          localStorage.removeItem('refresh_token');
           setToken(null);
+          setRefreshToken(null);
           setUser(null);
         });
     }
-  }, [token]);
+  }, [token, refreshToken]);
 
-  const handleLogin = (tok) => {
+  useEffect(() => {
+    if (!token || !refreshToken) return;
+    const interval = setInterval(() => {
+      fetch('http://localhost:8000/token/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error('refresh_failed');
+          return res.json();
+        })
+        .then((data) => {
+          localStorage.setItem('token', data.access_token);
+          localStorage.setItem('refresh_token', data.refresh_token);
+          setToken(data.access_token);
+          setRefreshToken(data.refresh_token);
+        })
+        .catch(handleLogout);
+    }, 25 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [token, refreshToken]);
+
+  const handleLogin = (tok, refTok) => {
     localStorage.setItem('token', tok);
+    localStorage.setItem('refresh_token', refTok);
     setToken(tok);
+    setRefreshToken(refTok);
     setPage('dashboard');
   };
 
   const handleLogout = () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('refresh_token');
     setToken(null);
+    setRefreshToken(null);
     setUser(null);
   };
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -22,7 +22,7 @@ export default function LoginPage({ onLogin, theme, goToRegister }) {
         throw new Error(data.detail || 'Invalid credentials');
       }
       const data = await res.json();
-      onLogin(data.access_token);
+      onLogin(data.access_token, data.refresh_token);
     } catch (err) {
       setError(err.message || 'Login failed');
     }

--- a/frontend/src/pages/StrategiesPage.jsx
+++ b/frontend/src/pages/StrategiesPage.jsx
@@ -44,6 +44,7 @@ export default function StrategiesPage() {
   const [tradeAmounts, setTradeAmounts] = useState({});
   const [selected, setSelected] = useState(null);
   const token = localStorage.getItem('token');
+  const refreshToken = localStorage.getItem('refresh_token');
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem('runningStrategyAmounts') || '{}');
@@ -76,7 +77,7 @@ export default function StrategiesPage() {
     const options = { method: 'POST', headers: { Authorization: `Bearer ${token}` } };
     if (!running) {
       options.headers['Content-Type'] = 'application/json';
-      options.body = JSON.stringify({ amount: parseFloat(amount) });
+      options.body = JSON.stringify({ amount: parseFloat(amount), refresh_token: refreshToken });
     }
     fetch(`http://localhost:8000${endpoint}`, options)
       .then((res) => {


### PR DESCRIPTION
## Summary
- support refresh tokens and new /token/refresh route
- keep frontend sessions alive with refresh tokens

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688ee7536b1083309aece5d82b962c2e