### PR TITLE
Improve dashboard bot control and layout

### DIFF
--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -9,7 +9,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import { Activity, DollarSign, Shield, Clock, Zap } from 'lucide-react';
+import { Activity, DollarSign, Shield, Clock } from 'lucide-react';
 import GlassCard from '../components/GlassCard';
 
 
@@ -33,7 +33,7 @@ const MainChart = ({ theme, data }) => {
   const axisColor = theme === 'dark' ? '#9ca3af' : '#4b5563';
   const gridColor = theme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)';
   return (
-    <GlassCard className="col-span-12 lg:col-span-8 h-[450px] flex flex-col">
+    <GlassCard className="col-span-12 lg:col-span-7 h-[350px] flex flex-col">
       <div className="flex justify-between items-start mb-4">
         <div>
           <h3 className="text-xl font-semibold text-gray-800 dark:text-white">Performance Overview</h3>
@@ -73,58 +73,105 @@ const MainChart = ({ theme, data }) => {
 };
 
 const BotControl = ({ token }) => {
-  const [config, setConfig] = useState(null);
+  const [strategies, setStrategies] = useState([]);
+  const [tradeLogs, setTradeLogs] = useState([]);
 
   useEffect(() => {
-    fetch('http://localhost:8000/bot', {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-      .then((res) => res.json())
-      .then(setConfig)
-      .catch(() => setConfig(null));
+    const fetchData = () => {
+      fetch('http://localhost:8000/strategies', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) =>
+          setStrategies((data.strategies || []).filter((s) => s.running))
+        )
+        .catch(() => setStrategies([]));
+
+      fetch('http://localhost:8000/trade_logs', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => setTradeLogs(data.logs || []))
+        .catch(() => setTradeLogs([]));
+    };
+    fetchData();
+    const id = setInterval(fetchData, 2000);
+    return () => clearInterval(id);
   }, [token]);
 
-  const toggleBot = () => {
-    if (!config) return;
-    fetch('http://localhost:8000/bot', {
+  const stopStrategy = (id) => {
+    fetch(`http://localhost:8000/strategy/${id}/stop`, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ ...config, is_active: !config.is_active }),
+      headers: { Authorization: `Bearer ${token}` },
     })
-      .then((res) => res.json())
-      .then(setConfig)
+      .then((res) => {
+        if (!res.ok) throw new Error();
+        setStrategies((prev) => prev.filter((s) => s.id !== id));
+      })
       .catch(() => {});
   };
 
-  const isBotActive = config ? config.is_active : false;
+  const parseTradeLog = (log) => {
+    const m = log.match(/(BUY|SELL)\s+(\w+)\s+qty\s+([\d.]+)/i);
+    if (!m) return { type: '', pair: '', qty: '', raw: log };
+    return { type: m[1].toUpperCase(), pair: m[2].toUpperCase(), qty: m[3] };
+  };
+
   return (
-    <GlassCard className="col-span-12 lg:col-span-4 h-full flex flex-col justify-between">
-      <div>
-        <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Bot Control</h3>
-        <div className="flex items-center justify-between mb-4">
-          <span className="text-gray-600 dark:text-gray-300">Status</span>
-          <div className={`flex items-center space-x-2 px-3 py-1 rounded-full text-sm ${isBotActive ? 'bg-green-500/30 text-green-300' : 'bg-red-500/30 text-red-300'}`}>
-            <div className={`w-2 h-2 rounded-full ${isBotActive ? 'bg-green-400' : 'bg-red-400'}`}></div>
-            <span>{isBotActive ? 'Active' : 'Stopped'}</span>
+    <GlassCard className="col-span-12 lg:col-span-5 h-[350px] flex flex-col">
+      <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">Bot Control</h3>
+      <div className="flex-grow overflow-y-auto">
+        <div className="mb-4">
+          <h4 className="font-semibold text-gray-700 dark:text-gray-200 mb-2">Running Strategies</h4>
+          {strategies.length ? (
+            <ul className="space-y-2">
+              {strategies.map((s) => (
+                <li key={s.id} className="flex justify-between items-center text-sm">
+                  <span className="text-gray-700 dark:text-gray-200">{s.name}</span>
+                  <button
+                    onClick={() => stopStrategy(s.id)}
+                    className="px-2 py-1 rounded bg-red-500/80 text-white"
+                  >
+                    Stop
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-gray-500 text-sm">No strategies running</p>
+          )}
+        </div>
+        <div>
+          <h4 className="font-semibold text-gray-700 dark:text-gray-200 mb-2">Trade Logs</h4>
+          <div className="max-h-40 overflow-y-auto">
+            <table className="w-full text-left text-xs text-gray-700 dark:text-gray-100">
+              <thead className="border-b border-gray-400/20 dark:border-white/20">
+                <tr>
+                  <th className="p-1">Type</th>
+                  <th className="p-1">Pair</th>
+                  <th className="p-1">Qty</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tradeLogs.map((log, i) => {
+                  const t = parseTradeLog(log);
+                  return (
+                    <tr key={i} className="border-b border-gray-400/10 dark:border-white/10">
+                      <td
+                        className={`p-1 font-bold ${t.type === 'BUY' ? 'text-green-500 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}
+                      >
+                        {t.type || log}
+                      </td>
+                      <td className="p-1">{t.pair}</td>
+                      <td className="p-1">{t.qty}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         </div>
-        {config ? (
-          <div className="space-y-3 text-gray-700 dark:text-gray-200">
-            <p><strong>Strategy:</strong> {config.strategy}</p>
-            <p><strong>Risk Level:</strong> {config.risk_level}</p>
-            <p><strong>Market:</strong> {config.market}</p>
-          </div>
-        ) : (
-          <p className="text-gray-500">No configuration</p>
-        )}
       </div>
-      <button onClick={toggleBot} className={`w-full py-3 mt-6 rounded-lg text-white font-bold text-lg transition-all duration-300 flex items-center justify-center space-x-2 ${isBotActive ? 'bg-red-500 hover:bg-red-600 shadow-red-500/30' : 'bg-green-500 hover:bg-green-600 shadow-green-500/30'} shadow-lg`}>
-        <Zap size={20}/>
-        <span>{isBotActive ? 'STOP BOT' : 'START BOT'}</span>
-      </button>
     </GlassCard>
   );
 };


### PR DESCRIPTION
## Summary
- Shrink dashboard performance chart and expand bot control panel
- Bot control now lists active strategies, provides stop buttons, and shows recent trade logs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688ef0a4eddc83308c5d2db067c8bed5