### PR TITLE
Fix dashboard stats initialization

### DIFF
--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -211,12 +211,13 @@ const TradeHistoryTable = ({ tradeHistory }) => (
 export default function DashboardPage({ theme, token }) {
   const [chartData, setChartData] = useState([]);
   const [tradeHistory, setTradeHistory] = useState([]);
-  const [stats, setStats] = useState({
+  const defaultStats = {
     total_profit: 0,
     win_rate: 0,
     active_trades: 0,
     avg_trade_duration: 0,
-  });
+  };
+  const [stats, setStats] = useState(defaultStats);
 
 
   useEffect(() => {
@@ -227,7 +228,13 @@ export default function DashboardPage({ theme, token }) {
       .then((data) => {
         setChartData(data.chart_data || []);
         setTradeHistory(data.trade_history || []);
-        setStats(data.stats || {});
+        const s = data.stats || {};
+        setStats({
+          total_profit: Number(s.total_profit) || 0,
+          win_rate: Number(s.win_rate) || 0,
+          active_trades: Number(s.active_trades) || 0,
+          avg_trade_duration: Number(s.avg_trade_duration) || 0,
+        });
       })
       .catch(() => {});
   }, [token]);


### PR DESCRIPTION
## Summary
- ensure dashboard stats default and parse numbers so metrics like total profit render

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688eff9edae88330af997df15acb84ac